### PR TITLE
Fix code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -318,7 +318,11 @@ document.addEventListener("DOMContentLoaded", function() {
     deleteButtons.forEach(button => {
         button.addEventListener("click", function() {
             const passwordId = button.getAttribute("data-id");
-            confirmDeleteForm.action = `/remove_password/${passwordId}`;
+            if (/^[a-zA-Z0-9]+$/.test(passwordId)) {
+                confirmDeleteForm.action = `/remove_password/${passwordId}`;
+            } else {
+                console.error("Invalid password ID");
+            }
             const deleteModal = new bootstrap.Modal(document.getElementById("deleteModal"));
             deleteModal.show();
         });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -311,13 +311,15 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     });
 
-    // Handle delete confirmation
+    // Handle delete confirmation with passwordId validation
     const deleteButtons = document.querySelectorAll(".delete-btn");
     const confirmDeleteForm = document.getElementById("confirmDeleteForm");
 
     deleteButtons.forEach(button => {
         button.addEventListener("click", function() {
             const passwordId = button.getAttribute("data-id");
+
+            // Validate passwordId to ensure it is alphanumeric
             if (/^[a-zA-Z0-9]+$/.test(passwordId)) {
                 confirmDeleteForm.action = `/remove_password/${passwordId}`;
             } else {

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -85,6 +85,28 @@
         {% endif %}
     </div>
 </main>
+
+<!-- Delete Confirmation Modal -->
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                Are you sure you want to delete this account?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form id="confirmDeleteForm" method="POST">
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% endblock %}
 
 {% block scripts %}
@@ -137,6 +159,25 @@ document.addEventListener("DOMContentLoaded", async function () {
                 icon.classList.remove("bi-eye");
                 icon.classList.add("bi-eye-slash");
             }
+        });
+    });
+
+    // Handle delete confirmation with passwordId validation
+    const deleteButtons = document.querySelectorAll(".delete-btn");
+    const confirmDeleteForm = document.getElementById("confirmDeleteForm");
+
+    deleteButtons.forEach(button => {
+        button.addEventListener("click", function() {
+            const passwordId = button.getAttribute("data-id");
+
+            // Validate passwordId to ensure it is alphanumeric
+            if (/^[a-zA-Z0-9]+$/.test(passwordId)) {
+                confirmDeleteForm.action = `/remove_password/${passwordId}`;
+            } else {
+                console.error("Invalid password ID");
+            }
+            const deleteModal = new bootstrap.Modal(document.getElementById("deleteModal"));
+            deleteModal.show();
         });
     });
 });

--- a/templates/view_folder.html
+++ b/templates/view_folder.html
@@ -170,24 +170,24 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     });
 
-    // Handle delete confirmation
+    // Handle delete confirmation with passwordId validation
     const deleteButtons = document.querySelectorAll(".delete-btn");
     const confirmDeleteForm = document.getElementById("confirmDeleteForm");
 
     deleteButtons.forEach(button => {
         button.addEventListener("click", function() {
-            const passwordId = sanitizeInput(button.getAttribute("data-id"));
-            confirmDeleteForm.action = `/remove_password/${passwordId}`;
+            const passwordId = button.getAttribute("data-id");
+
+            // Validate passwordId to ensure it is alphanumeric
+            if (/^[a-zA-Z0-9]+$/.test(passwordId)) {
+                confirmDeleteForm.action = `/remove_password/${passwordId}`;
+            } else {
+                console.error("Invalid password ID");
+            }
             const deleteModal = new bootstrap.Modal(document.getElementById("deleteModal"));
             deleteModal.show();
         });
     });
 });
-
-function sanitizeInput(input) {
-    const element = document.createElement('div');
-    element.innerText = input;
-    return element.innerHTML;
-}
 </script>
 {% endblock %}


### PR DESCRIPTION
Fixes [https://github.com/av1155/FlaskKeyring/security/code-scanning/10](https://github.com/av1155/FlaskKeyring/security/code-scanning/10)

To fix the problem, we need to ensure that the `passwordId` is properly sanitized before being used to construct the URL. One way to do this is to validate that `passwordId` contains only expected characters (e.g., alphanumeric characters) before using it. This can be done using a regular expression.

- Validate the `passwordId` to ensure it contains only alphanumeric characters.
- If the `passwordId` is invalid, handle the error appropriately (e.g., by not performing the action or showing an error message).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
