### PR TITLE
Fix code scanning alert no. 12: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,8 +38,11 @@ if os.getenv("FLASK_ENV") == "production":
             parsed_url = urlparse(request.url.replace("\\", ""))
             # Allow redirection only if the request host matches the current server's host
             if parsed_url.netloc == request.host:
-                secure_url = request.url.replace("http://", "https://", 1)
-                return redirect(secure_url, code=301)
+                secure_url = request.url.replace("http://", "https://", 1).replace("\\", "/")
+                if not urlparse(secure_url).netloc and not urlparse(secure_url).scheme:
+                    return redirect(secure_url, code=301)
+                else:
+                    return redirect("/", code=301)
             else:
                 return redirect("/", code=301)
 

--- a/app.py
+++ b/app.py
@@ -35,12 +35,13 @@ if os.getenv("FLASK_ENV") == "production":
     def before_request():
         # Redirect all non-HTTPS requests to HTTPS
         if request.url.startswith("http://"):
-            parsed_url = urlparse(request.url.replace('\\', ''))
-            if not parsed_url.netloc and not parsed_url.scheme:
+            parsed_url = urlparse(request.url.replace("\\", ""))
+            # Allow redirection only if the request host matches the current server's host
+            if parsed_url.netloc == request.host:
                 secure_url = request.url.replace("http://", "https://", 1)
                 return redirect(secure_url, code=301)
             else:
-                return redirect('/', code=301)
+                return redirect("/", code=301)
 
 
 # Configure app and extensions

--- a/app.py
+++ b/app.py
@@ -35,8 +35,12 @@ if os.getenv("FLASK_ENV") == "production":
     def before_request():
         # Redirect all non-HTTPS requests to HTTPS
         if request.url.startswith("http://"):
-            secure_url = request.url.replace("http://", "https://", 1)
-            return redirect(secure_url, code=301)
+            parsed_url = urlparse(request.url.replace('\\', ''))
+            if not parsed_url.netloc and not parsed_url.scheme:
+                secure_url = request.url.replace("http://", "https://", 1)
+                return redirect(secure_url, code=301)
+            else:
+                return redirect('/', code=301)
 
 
 # Configure app and extensions


### PR DESCRIPTION
Fixes [https://github.com/av1155/FlaskKeyring/security/code-scanning/12](https://github.com/av1155/FlaskKeyring/security/code-scanning/12)

To fix the problem, we need to validate the `request.url` before using it to construct the `secure_url`. We can use the `urlparse` function from the Python standard library to parse the URL and ensure that it does not contain an explicit host name. This will help prevent untrusted URL redirection by ensuring that only relative paths are allowed for redirection.

We will modify the `before_request` function to include this validation step. Specifically, we will parse the `request.url`, remove any backslashes, and check that the `netloc` attribute is empty. If the validation fails, we will redirect to the home page instead of the potentially malicious URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
