### PR TITLE
Fix code scanning alert no. 15: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,12 +40,15 @@ if os.getenv("FLASK_ENV") == "production":
             # Check that the host is the same to avoid open redirects
             if parsed_url.netloc == request.host:
                 # Replace HTTP with HTTPS to construct the secure URL
-                secure_url = request.url.replace("http://", "https://", 1)
+                secure_url = request.url.replace("http://", "https://", 1).replace('\\', '')
 
-                # Validate the secure URL has a scheme and netloc
+                # Validate the secure URL does not have a netloc or scheme
                 secure_parsed = urlparse(secure_url)
-                if secure_parsed.scheme == "https" and secure_parsed.netloc:
+                if not secure_parsed.netloc and not secure_parsed.scheme:
                     return redirect(secure_url, code=301)
+
+        # Do nothing if already HTTPS or conditions are not met
+        return redirect('/', code=301)
 
         # Do nothing if already HTTPS or conditions are not met
         return None


### PR DESCRIPTION
Fixes [https://github.com/av1155/FlaskKeyring/security/code-scanning/15](https://github.com/av1155/FlaskKeyring/security/code-scanning/15)

To fix the problem, we need to ensure that the `secure_url` is validated properly before performing the redirection. We can use the `urlparse` function to check that the `secure_url` does not contain an explicit host name and is a relative path. Additionally, we should handle backslashes and malformed URLs to ensure they are not misinterpreted by browsers.

1. Replace backslashes in the `secure_url` with empty strings.
2. Use `urlparse` to check that the `secure_url` does not have a `netloc` or `scheme`.
3. If the `secure_url` is valid, perform the redirection; otherwise, redirect to the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
